### PR TITLE
Corrected citation: Graves et. al -2016 -> +2006

### DIFF
--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -842,7 +842,7 @@ def ctc_loss_v3(labels,
                 name=None):
   """Computes CTC (Connectionist Temporal Classification) loss.
 
-  This op implements the CTC loss as presented in (Graves et al., 2016).
+  This op implements the CTC loss as presented in (Graves et al., 2006).
 
   Notes:
 
@@ -882,7 +882,7 @@ def ctc_loss_v3(labels,
   References:
       Connectionist Temporal Classification - Labeling Unsegmented Sequence Data
       with Recurrent Neural Networks:
-        [Graves et al., 2016](https://dl.acm.org/citation.cfm?id=1143891)
+        [Graves et al., 2006](https://dl.acm.org/citation.cfm?id=1143891)
         ([pdf](http://www.cs.toronto.edu/~graves/icml_2006.pdf))
   """
   if isinstance(labels, sparse_tensor.SparseTensor):


### PR DESCRIPTION
[Connectionist temporal Classification](https://dl.acm.org/doi/10.1145/1143844.1143891) year of publication is 2006 and not 2016 as shown in the link.
